### PR TITLE
Fix menu JS init and correct audio toggle label

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,8 @@
             const audio = document.getElementById('bgmusic');
             const audioControl = document.getElementById('audioControl');
 
-            audioControl.textContent = audio.paused ? 'Pause Audio' : 'Play Audio';
+            // Show the opposite action since the button controls playback
+            audioControl.textContent = audio.paused ? 'Play Audio' : 'Pause Audio';
 
             audioControl.addEventListener('click', function () {
                 toggleAudio();

--- a/script.js
+++ b/script.js
@@ -1,27 +1,30 @@
-// Toggle menu function
-function toggleMenu() {
-    var nav = document.querySelector('.nav-links');
-    nav.style.width = nav.style.width === '250px' ? '0' : '250px';
-    // Toggle hamburger to X and vice versa
-    document.querySelector('.menu').classList.toggle('change');
-}
-
-// Close the menu when clicking outside of it
-document.addEventListener('click', function(event) {
-    var nav = document.querySelector('.nav-links');
-    var menuButton = document.querySelector('.menu');
-    var clickInsideMenu = menuButton.contains(event.target);
-    var clickInsideNav = nav.contains(event.target);
-
-    if (!clickInsideMenu && !clickInsideNav && nav.style.width === '250px') {
-        nav.style.width = '0';
-        //Icon goes back to hamburger when closing by clicking outside
-        menuButton.classList.remove('change');
+// Setup menu interactions once the DOM has loaded
+document.addEventListener('DOMContentLoaded', function () {
+    // Toggle menu function
+    function toggleMenu() {
+        var nav = document.querySelector('.nav-links');
+        nav.style.width = nav.style.width === '250px' ? '0' : '250px';
+        // Toggle hamburger to X and vice versa
+        document.querySelector('.menu').classList.toggle('change');
     }
-});
 
-// Ensures the menu toggle only activates when the menu button is clicked
-document.querySelector('.menu').addEventListener('click', function(event) {
-    event.stopPropagation();
-    toggleMenu();
+    // Close the menu when clicking outside of it
+    document.addEventListener('click', function(event) {
+        var nav = document.querySelector('.nav-links');
+        var menuButton = document.querySelector('.menu');
+        var clickInsideMenu = menuButton.contains(event.target);
+        var clickInsideNav = nav.contains(event.target);
+
+        if (!clickInsideMenu && !clickInsideNav && nav.style.width === '250px') {
+            nav.style.width = '0';
+            // Icon goes back to hamburger when closing by clicking outside
+            menuButton.classList.remove('change');
+        }
+    });
+
+    // Ensures the menu toggle only activates when the menu button is clicked
+    document.querySelector('.menu').addEventListener('click', function(event) {
+        event.stopPropagation();
+        toggleMenu();
+    });
 });


### PR DESCRIPTION
## Summary
- delay menu script setup until DOMContentLoaded so it can find elements
- fix initial audio button text so it reflects current state

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e928f573c832a8b29ce54d9d1b0dd