### PR TITLE
Improve about page layout and fix navigation visuals

### DIFF
--- a/about.css
+++ b/about.css
@@ -1,105 +1,189 @@
-/* about.css */
-body {
-    font-family: Arial, sans-serif;
-    margin: 0;
-    padding: 0;
-    line-height: 1.6;
-    color: #333;
-    background-color: #f4f4f4;
+.about-page {
+    padding: clamp(4rem, 8vw, 6rem) 1.5rem 3rem;
 }
 
-.page-header {
-    background: #000;
-    color: #fff;
-    padding: 20px;
+.about-hero {
     text-align: center;
+    margin: 0 auto clamp(2.5rem, 6vw, 3.5rem);
+    max-width: 760px;
 }
 
-.page-header h1 {
+.about-hero h1 {
+    margin-bottom: 0.75rem;
+    font-size: clamp(2.5rem, 6vw, 3.75rem);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.about-hero__tagline {
     margin: 0;
-    font-size: 2.5rem;
+    font-size: clamp(1.1rem, 3vw, 1.35rem);
+    font-weight: 300;
+    color: rgba(255, 255, 255, 0.8);
 }
 
-main {
-    padding: 20px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: calc(100vh - 80px); /* Adjusting for header and footer height */
+.about-layout {
+    display: grid;
+    gap: clamp(2rem, 5vw, 3.5rem);
+    max-width: min(1100px, 100%);
+    margin: 0 auto;
 }
 
-.about-me {
+@media (min-width: 880px) {
+    .about-layout {
+        grid-template-columns: minmax(240px, 320px) 1fr;
+        align-items: start;
+    }
+}
+
+.profile-card {
+    background: rgba(10, 13, 18, 0.85);
+    border-radius: 1.5rem;
+    padding: clamp(2rem, 4vw, 2.75rem);
+    text-align: center;
     display: flex;
     flex-direction: column;
+    gap: 1.25rem;
     align-items: center;
-    text-align: center;
-    background-color: #fff;
-    border-radius: 8px;
-    padding: 40px; /* Increased padding */
-    max-width: 1000px; /* Increased max-width */
-    margin: 0 auto;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 24px 40px rgba(0, 0, 0, 0.45);
 }
 
-.profile-photo {
-    width: 150px;
-    height: 150px;
+.profile-card__photo {
+    width: clamp(160px, 30vw, 200px);
+    height: clamp(160px, 30vw, 200px);
     border-radius: 50%;
-    margin-bottom: 20px;
     object-fit: cover;
+    border: 3px solid var(--color-accent);
+    box-shadow: 0 18px 35px rgba(0, 0, 0, 0.4);
 }
 
-.description h2 {
+.profile-card__name {
     margin: 0;
-    font-size: 2.5rem; /* Increased font size for headings */
-    color: #000; /* Better contrast on white background */
+    font-size: clamp(1.75rem, 4vw, 2.25rem);
+    letter-spacing: 0.04em;
 }
 
-.description p {
-    margin: 15px 0;
-    font-size: 1.1rem;
+.profile-card__role {
+    margin: -0.5rem 0 0;
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.profile-card__highlights {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    color: rgba(255, 255, 255, 0.8);
     line-height: 1.6;
 }
 
-.site-footer {
-    text-align: center;
-    padding: 15px 0;
-    position: fixed;
-    width: 100%;
-    bottom: 0;
-    box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
+.profile-card__highlights li {
+    position: relative;
+    padding-left: 1.5rem;
+    text-align: left;
 }
 
-.site-footer--dark {
-    background: #000;
-    color: #fff;
+.profile-card__highlights li::before {
+    content: '▹';
+    position: absolute;
+    left: 0;
+    color: var(--color-accent);
 }
 
-.site-footer--dark a {
-    color: #fff;
-    text-decoration: none;
+.about-details {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.75rem, 5vw, 2.5rem);
 }
 
-.site-footer--dark a:hover {
-    text-decoration: underline;
+.about-details__section {
+    background: rgba(10, 13, 18, 0.75);
+    border-radius: 1.5rem;
+    padding: clamp(1.75rem, 4vw, 2.25rem);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
 }
 
-@media (max-width: 768px) {
-    .about-me {
-        padding: 20px; /* Adjusted padding for smaller screens */
-        max-width: 90%; /* Adjusted max-width for smaller screens */
+.about-details__section h3 {
+    margin-top: 0;
+    font-size: clamp(1.5rem, 4vw, 1.85rem);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.about-details__section p {
+    margin-bottom: 0;
+    line-height: 1.8;
+    color: rgba(255, 255, 255, 0.82);
+}
+
+.about-details__grid {
+    display: grid;
+    gap: clamp(1rem, 3vw, 1.75rem);
+    background: transparent;
+    padding: 0;
+    border: none;
+    box-shadow: none;
+}
+
+@media (min-width: 640px) {
+    .about-details__grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+.about-details__card {
+    background: rgba(10, 13, 18, 0.85);
+    border-radius: 1.25rem;
+    padding: clamp(1.25rem, 3vw, 1.75rem);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.about-details__card h4 {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+    font-size: 1.1rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.about-details__card ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    color: rgba(255, 255, 255, 0.78);
+}
+
+.about-details__card li {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    line-height: 1.6;
+}
+
+.about-details__card li::before {
+    content: '•';
+    color: var(--color-accent);
+    line-height: 1;
+}
+
+@media (max-width: 599px) {
+    .about-page {
+        padding-top: 3.5rem;
     }
 
-    .profile-photo {
-        width: 120px;
-        height: 120px;
-    }
-
-    .description h2 {
-        font-size: 2rem; /* Adjust font size for smaller screens */
-    }
-
-    .description p {
-        font-size: 1rem;
+    .profile-card {
+        padding: 2rem 1.75rem;
     }
 }

--- a/about.html
+++ b/about.html
@@ -15,16 +15,64 @@
         <div id="nav-placeholder"></div>
     </header>
 
-    <main>
-        <section class="page-header">
-            <h1>About Me</h1>
+    <main class="about-page">
+        <section class="about-hero">
+            <h1>About David</h1>
+            <p class="about-hero__tagline">Network administrator, lifelong learner, and outdoor enthusiast.</p>
         </section>
-        <section class="about-me">
-            <img src="DWard2024.jpg" alt="David Ward" class="profile-photo">
-            <div class="description">
-                <h2>David Ward</h2>
-                <p>Hello, my name is David Ward. My favorite hobbies include ice hockey, video games, and riding ATVs in the woods. I am currently a student at Thaddeus Stevens College of Technology, pursuing a career in Computer Networking.</p>
-            </div>
+
+        <section class="about-layout">
+            <aside class="profile-card">
+                <img src="DWard2024.jpg" alt="David Ward" class="profile-card__photo">
+                <h2 class="profile-card__name">David Ward</h2>
+                <p class="profile-card__role">Network Administrator &bull; Warfel Construction</p>
+                <ul class="profile-card__highlights">
+                    <li>Computer Networking student at Thaddeus Stevens College of Technology</li>
+                    <li>Passionate about ice hockey, gaming, and exploring new trails on ATVs</li>
+                    <li>Driven to build secure, resilient network infrastructure</li>
+                </ul>
+            </aside>
+
+            <article class="about-details">
+                <section class="about-details__section">
+                    <h3>Hi, I'm David!</h3>
+                    <p>
+                        Technology has always been my favorite way to solve real-world problems. During the day I keep the
+                        team at Warfel Construction connected as a network administrator, and by night I'm sharpening my
+                        skills at Thaddeus Stevens College of Technology. The combination of professional experience and
+                        classroom learning keeps me curious and constantly improving.
+                    </p>
+                </section>
+
+                <section class="about-details__section">
+                    <h3>What keeps me inspired</h3>
+                    <p>
+                        Whether I'm on the ice playing hockey, teaming up with friends online, or navigating wooded trails
+                        on an ATV, I love activities that challenge my reflexes and teamwork. That same energy fuels the way
+                        I approach technology—always looking for new ways to collaborate and stay a step ahead of the next
+                        challenge.
+                    </p>
+                </section>
+
+                <section class="about-details__section about-details__grid">
+                    <div class="about-details__card">
+                        <h4>Focus Areas</h4>
+                        <ul>
+                            <li>Secure network design</li>
+                            <li>Systems administration</li>
+                            <li>End-user support &amp; training</li>
+                        </ul>
+                    </div>
+                    <div class="about-details__card">
+                        <h4>Currently Exploring</h4>
+                        <ul>
+                            <li>Automation for routine network tasks</li>
+                            <li>Cloud-based infrastructure solutions</li>
+                            <li>Strategies for building resilient teams</li>
+                        </ul>
+                    </div>
+                </section>
+            </article>
         </section>
     </main>
 

--- a/style.css
+++ b/style.css
@@ -44,30 +44,6 @@ img {
 
 .site-footer--dark {
     background: #000;
-
-body {
-    overflow-x: hidden;
-}
-
-img {
-    max-width: 100%;
-    display: block;
-}
-
-.site-header {
-    position: relative;
-    z-index: 1000;
-}
-
-.site-footer {
-    background: var(--color-surface);
-    color: var(--color-text-light);
-    text-align: center;
-    padding: 1rem 1.5rem;
-}
-
-.site-footer--dark {
-    background: #000;
 }
 
 /* Hero section */
@@ -82,6 +58,8 @@ img {
     gap: 1.5rem;
     padding: 2.5rem 1.5rem;
     overflow: hidden;
+    background: radial-gradient(circle at top, rgba(39, 176, 215, 0.25), rgba(5, 7, 10, 0.9)),
+        url('photo.jpg') center / cover no-repeat;
 }
 
 .hero__media {
@@ -178,11 +156,6 @@ img {
     background: transparent;
     border: 0;
     padding: 0;
-    width: 100%;
-    height: 100%;
-    background: transparent;
-    border: 0;
-    padding: 0;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -216,11 +189,7 @@ img {
 }
 
 .menu.change .hamburger-icon span:nth-child(1) {
-    transform: translateY(9px) rotate(45deg);
-}
-
-.menu.change .hamburger-icon span:nth-child(1) {
-    transform: translateY(6px) rotate(-45deg);
+    transform: translateY(6px) rotate(45deg);
 }
 
 .menu.change .hamburger-icon span:nth-child(2) {
@@ -228,8 +197,7 @@ img {
 }
 
 .menu.change .hamburger-icon span:nth-child(3) {
-    transform: translateY(-9px) rotate(-45deg);
-    transform: translateY(-6px) rotate(45deg);
+    transform: translateY(-6px) rotate(-45deg);
 }
 
 .hamburger-icon:focus-visible {


### PR DESCRIPTION
## Summary
- redesign the about page with a structured hero, profile card, and detailed sections
- refresh about page styling to match the dark theme and improve readability
- fix the hamburger animation and add a fallback image/gradient for the home hero background

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f78b25af20832ab92988573c652eb4