### PR TITLE
Restore home page content with refreshed layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>David Ward | Blog</title>
-    <script src="script.js"></script>
+    <title>David Ward | Home</title>
+    <script src="script.js" defer></script>
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -16,48 +16,96 @@
             <source src="movie.mp4" type="video/mp4">
             Your browser does not support HTML5 video.
         </video>
-        <audio id="bgmusic" src="audio.mp3" autoplay>
+
+        <div class="overlay">
+            <header class="site-header">
+                <button id="audioControl" type="button" aria-controls="bgmusic" aria-pressed="false"
+                    aria-label="Toggle background audio">
+                    Play Audio
+                </button>
+                <div id="nav-placeholder"></div>
+            </header>
+
+            <main class="home-content">
+                <section class="hero" aria-labelledby="home-title">
+                    <div class="hero-copy">
+                        <p class="hero-eyebrow">Network Administrator · IT Strategist</p>
+                        <h1 id="home-title">David Ward</h1>
+                        <p class="hero-tagline">Network Administrator at Warfel Construction</p>
+                        <p class="hero-description">
+                            I build resilient infrastructure, keep critical systems secure, and translate complex technology into
+                            solutions that make work easier for every team member. My focus is on dependable support, clear
+                            communication, and long-term partnerships.
+                        </p>
+                        <div class="hero-actions">
+                            <a class="btn primary" href="about.html">Learn More About Me</a>
+                            <a class="btn" href="resume.html">View Resume</a>
+                        </div>
+                    </div>
+                    <div class="hero-metrics" aria-label="Career highlights">
+                        <article class="metric-card">
+                            <h2>13<span>+</span></h2>
+                            <p>Years delivering network and systems reliability.</p>
+                        </article>
+                        <article class="metric-card">
+                            <h2>24/7</h2>
+                            <p>Support mindset that keeps construction crews productive.</p>
+                        </article>
+                        <article class="metric-card">
+                            <h2>100%</h2>
+                            <p>Commitment to security, VPN adoption, and proactive monitoring.</p>
+                        </article>
+                    </div>
+                </section>
+
+                <section class="intro" aria-labelledby="intro-title">
+                    <h2 id="intro-title">Bridging Business Goals and Technology</h2>
+                    <p>
+                        From modernizing networks to empowering end users, I partner with stakeholders to plan, deploy, and
+                        support the tools they rely on every day. My work blends technical depth with a people-first approach, so
+                        teams feel confident and connected wherever the job takes them.
+                    </p>
+                </section>
+
+                <section class="focus-areas" aria-labelledby="focus-title">
+                    <h2 id="focus-title">Where I Bring the Most Value</h2>
+                    <div class="focus-grid">
+                        <article class="focus-card">
+                            <h3>Infrastructure Leadership</h3>
+                            <p>Designing networks that scale with demand, align with budget, and stay ahead of downtime.</p>
+                        </article>
+                        <article class="focus-card">
+                            <h3>Security &amp; Continuity</h3>
+                            <p>Implementing VPN standards, layered defenses, and backup strategies that protect every jobsite.</p>
+                        </article>
+                        <article class="focus-card">
+                            <h3>Empowering People</h3>
+                            <p>Coaching teams through change, documenting processes, and keeping communication simple and clear.</p>
+                        </article>
+                    </div>
+                </section>
+
+                <section class="callout" aria-labelledby="callout-title">
+                    <div class="callout-content">
+                        <h2 id="callout-title">Let&rsquo;s Connect</h2>
+                        <p>
+                            I&rsquo;m always excited to talk about new challenges, whether that&rsquo;s scaling infrastructure, improving
+                            resilience, or mentoring teams. Reach out and we&rsquo;ll build a plan together.
+                        </p>
+                        <a class="btn primary" href="mailto:dward@example.com">Start a Conversation</a>
+                    </div>
+                </section>
+            </main>
+
+            <footer>
+                <p>Welcome To My Journey</p>
+            </footer>
+        </div>
+
+        <audio id="bgmusic" src="audio.mp3">
             Your browser does not support the audio element.
         </audio>
-        <button id="audioControl">Play Audio</button>
-
-        <div id="nav-placeholder"></div>
-        <div class="personal-info">
-            <h1>David Ward</h1>
-            <p>Network Administrator At Warfel Construction</p>
-        </div>
     </div>
-
-
-    <script>
-        document.addEventListener('DOMContentLoaded', function () {
-            const audio = document.getElementById('bgmusic');
-            const audioControl = document.getElementById('audioControl');
-
-            // Show the opposite action since the button controls playback
-            audioControl.textContent = audio.paused ? 'Play Audio' : 'Pause Audio';
-
-            audioControl.addEventListener('click', function () {
-                toggleAudio();
-            });
-        });
-
-        function toggleAudio() {
-            const audio = document.getElementById('bgmusic');
-            const audioControl = document.getElementById('audioControl');
-            if (audio.paused) {
-                audio.play();
-                audioControl.textContent = 'Pause Audio';
-            } else {
-                audio.pause();
-                audioControl.textContent = 'Play Audio';
-            }
-        }
-    </script>
-
-    <footer>
-        <p>Welcome To My Journey</p>
-    </footer>
 </body>
 
 </html>

--- a/script.js
+++ b/script.js
@@ -28,11 +28,42 @@ function setupMenuInteractions() {
     });
 }
 
+function setupAudioControls() {
+    var audio = document.getElementById('bgmusic');
+    var control = document.getElementById('audioControl');
+
+    if (!audio || !control) {
+        return;
+    }
+
+    function updateLabel() {
+        control.textContent = audio.paused ? 'Play Audio' : 'Pause Audio';
+        control.setAttribute('aria-pressed', audio.paused ? 'false' : 'true');
+    }
+
+    // Ensure audio is paused on load until user interaction
+    audio.pause();
+    updateLabel();
+
+    control.addEventListener('click', function () {
+        if (audio.paused) {
+            audio.play();
+        } else {
+            audio.pause();
+        }
+    });
+
+    audio.addEventListener('play', updateLabel);
+    audio.addEventListener('pause', updateLabel);
+    audio.addEventListener('ended', updateLabel);
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     var placeholder = document.getElementById('nav-placeholder');
 
     if (!placeholder) {
         setupMenuInteractions();
+        setupAudioControls();
         return;
     }
 
@@ -43,9 +74,11 @@ document.addEventListener('DOMContentLoaded', function () {
         .then(function (html) {
             placeholder.innerHTML = html;
             setupMenuInteractions();
+            setupAudioControls();
         })
         .catch(function (error) {
             console.error('Failed to load navigation:', error);
             setupMenuInteractions();
+            setupAudioControls();
         });
 });

--- a/style.css
+++ b/style.css
@@ -1,29 +1,67 @@
-/* This is for the hamburger bar and audio of the home page */
-
-body,
-html {
+/* Global layout */
+html,
+body {
   height: 100%;
   margin: 0;
-  font-family: Arial, sans-serif;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: #f5f7fa;
+  background-color: #06121d;
   overflow-x: hidden;
 }
 
-.bg video {
-  position: relative;
-  right: 0;
-  bottom: 0;
-  min-width: 100%;
-  min-height: 100%;
-  width: auto;
-  height: auto;
-  z-index: -100;
-  background-size: cover;
+body {
+  display: flex;
+  flex-direction: column;
 }
 
+/* Background video */
 .bg {
   position: relative;
-  height: 100%;
+  flex: 1;
+  min-height: 100vh;
   overflow: hidden;
+}
+
+.bg video {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: -2;
+}
+
+.overlay {
+  position: relative;
+  min-height: 100vh;
+  padding: clamp(2rem, 6vw, 4rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 6vw, 3.5rem);
+  background: linear-gradient(135deg, rgba(6, 18, 29, 0.95), rgba(13, 46, 66, 0.75));
+  backdrop-filter: blur(6px);
+  z-index: 1;
+}
+
+.overlay::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(210deg, rgba(3, 11, 19, 0.9) 0%, rgba(7, 25, 38, 0.45) 55%, rgba(2, 7, 12, 0.85) 100%);
+  z-index: -1;
+}
+
+/* Header & navigation */
+.site-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  position: relative;
+  z-index: 10;
+}
+
+#nav-placeholder {
+  margin-left: auto;
 }
 
 .menu {
@@ -31,7 +69,7 @@ html {
   top: 20px;
   right: 30px;
   font-size: 50px;
-  color: white;
+  color: #ffffff;
   cursor: pointer;
   z-index: 1000;
 }
@@ -62,7 +100,7 @@ html {
   display: flex;
   width: 25px;
   height: 3px;
-  background: white;
+  background: #ffffff;
   margin: 6px auto;
   transition: all 0.3s ease-in-out;
   z-index: 4;
@@ -74,71 +112,294 @@ html {
   top: 0;
   height: 100%;
   width: 0;
-  background: rgba(0, 0, 0, 0.9);
+  background: rgba(3, 11, 19, 0.92);
+  backdrop-filter: blur(8px);
   overflow: hidden;
   transition: width 0.5s;
-  padding-top: 60px;
+  padding-top: 80px;
   text-align: left;
   z-index: 999;
 }
 
 .nav-links a {
-  padding: 10px 15px;
+  padding: 12px 24px;
   text-decoration: none;
-  font-size: 20px;
-  color: white;
+  font-size: 18px;
+  letter-spacing: 0.02em;
+  color: #f5f7fa;
   display: block;
-  transition: 0.3s;
+  transition: background 0.3s ease, transform 0.3s ease;
 }
 
 .nav-links a:hover {
-  background: lightslategray;
-  color: white;
+  background: rgba(65, 196, 217, 0.2);
+  transform: translateX(4px);
 }
 
-.personal-info {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
-  color: white;
-  z-index: 1;
-  font-size: 24px;
-}
-
-#bgvideo {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  height: 100%;
-  z-index: -1;
-  object-fit: cover;
-}
-
+/* Audio control */
 #audioControl {
-  position: fixed;
-  top: 10px;
-  left: 20px;
-  padding: 10px 20px;
-  z-index: 3;
-  background: white;
-  color: black;
-  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(245, 247, 250, 0.45);
+  background: rgba(6, 18, 29, 0.75);
+  color: #f5f7fa;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
   cursor: pointer;
-  border-radius: 5px;
+  transition: background 0.3s ease, border-color 0.3s ease, transform 0.2s ease;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }
 
-footer {
-  position: fixed;
-  bottom: 0;
+#audioControl:focus,
+#audioControl:hover {
+  background: rgba(65, 196, 217, 0.9);
+  border-color: rgba(65, 196, 217, 0.9);
+  color: #06253a;
+  transform: translateY(-1px);
+}
+
+/* Main content */
+.home-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 6vw, 4rem);
+  max-width: 1100px;
   width: 100%;
-  background: #333;
-  color: #fff;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(2rem, 6vw, 3.5rem);
+  align-items: stretch;
+}
+
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  text-shadow: 0 3px 20px rgba(0, 0, 0, 0.5);
+}
+
+.hero-eyebrow {
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #9cd3f0;
+  margin: 0;
+}
+
+.hero h1 {
+  font-size: clamp(2.75rem, 6vw, 4.25rem);
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.hero-tagline {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #e1f1ff;
+}
+
+.hero-description {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: #d2e6f4;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(245, 247, 250, 0.4);
+  text-decoration: none;
+  color: #f5f7fa;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: background 0.3s ease, border-color 0.3s ease, transform 0.2s ease;
+  backdrop-filter: blur(3px);
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-1px);
+  border-color: rgba(65, 196, 217, 0.8);
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, #45b4ff, #54e0d3);
+  border-color: transparent;
+  color: #031520;
+}
+
+.btn.primary:hover,
+.btn.primary:focus {
+  background: linear-gradient(135deg, #54e0d3, #7df8de);
+  color: #041d2c;
+}
+
+.hero-metrics {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.metric-card {
+  background: rgba(6, 20, 32, 0.7);
+  border: 1px solid rgba(150, 219, 255, 0.2);
+  border-radius: 20px;
+  padding: 1.75rem 1.5rem;
+  box-shadow: 0 20px 45px rgba(3, 10, 18, 0.5);
+  backdrop-filter: blur(6px);
   text-align: center;
-  padding: 10px 20px;
-  z-index: 2;
+}
+
+.metric-card h2 {
+  margin: 0 0 0.75rem;
+  font-size: 2.4rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #7fefff;
+}
+
+.metric-card h2 span {
+  font-size: 1.4rem;
+}
+
+.metric-card p {
+  margin: 0;
+  color: #cde6f7;
+  line-height: 1.5;
+}
+
+/* Intro */
+.intro {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: rgba(3, 11, 19, 0.55);
+  border-radius: 24px;
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+  border: 1px solid rgba(136, 209, 247, 0.25);
+  box-shadow: 0 22px 48px rgba(4, 12, 20, 0.45);
+}
+
+.intro h2 {
+  margin: 0;
+  font-size: clamp(1.9rem, 5vw, 2.6rem);
+}
+
+.intro p {
+  margin: 0;
+  color: #cfe2f1;
+  line-height: 1.8;
+}
+
+/* Focus areas */
+.focus-areas {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.focus-areas h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.focus-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.focus-card {
+  background: rgba(4, 15, 24, 0.65);
+  border-radius: 18px;
+  padding: 1.75rem;
+  border: 1px solid rgba(120, 205, 240, 0.2);
+  box-shadow: 0 20px 40px rgba(3, 12, 21, 0.45);
+}
+
+.focus-card h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.2rem;
+}
+
+.focus-card p {
+  margin: 0;
+  color: #c4ddef;
+  line-height: 1.7;
+}
+
+/* Callout */
+.callout {
+  background: rgba(84, 224, 211, 0.12);
+  border-radius: 24px;
+  border: 1px solid rgba(125, 248, 222, 0.4);
+  padding: clamp(2rem, 5vw, 3rem);
+  box-shadow: 0 25px 55px rgba(4, 14, 23, 0.45);
+  max-width: 850px;
+}
+
+.callout h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.9rem, 5vw, 2.6rem);
+  color: #f3fffe;
+}
+
+.callout p {
+  margin: 0 0 1.5rem;
+  color: #d7edf6;
+  line-height: 1.7;
+}
+
+/* Footer */
+footer {
+  text-align: center;
+  padding: 1.5rem 0 0.5rem;
+  color: rgba(229, 239, 247, 0.82);
+  font-size: 0.9rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 960px) {
+  .home-content {
+    margin-top: 1rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .overlay {
+    padding-top: 6rem;
+  }
+
+  #audioControl {
+    position: fixed;
+    top: 16px;
+    left: 20px;
+    z-index: 1001;
+  }
+}
+
+@media (max-width: 540px) {
+  .hero-actions {
+    flex-direction: column;
+  }
+
+  .metric-card {
+    padding: 1.5rem 1.25rem;
+  }
 }


### PR DESCRIPTION
## Summary
- rebuild the home page hero and supporting sections so key text and calls to action display reliably
- update the styling to emphasize readability with stronger contrast, new metrics cards, and refreshed focus area layout
- retain the background video and audio toggle while keeping music muted until visitors press Play

## Testing
- not run (static content changes)

------
https://chatgpt.com/codex/tasks/task_e_68f7a25f1c40832aa37c7dde846c1df8