### PR TITLE
Clean up duplicated homepage sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,10 @@
 
         <div class="overlay">
             <header class="site-header">
+                <button id="audioControl" type="button" aria-controls="bgmusic" aria-pressed="false"
+                    aria-label="Toggle background audio">
+                    Play Audio
+                </button>
                 <div id="nav-placeholder"></div>
             </header>
 
@@ -88,71 +92,6 @@
                                 Modernization is an ongoing journey. I align upgrades with budgets and business priorities so
                                 investments pay off in productivity, security, and user experience.
                             </p>
-
-        <div class="overlay">
-            <header class="site-header">
-                <button id="audioControl" type="button" aria-controls="bgmusic" aria-pressed="false"
-                    aria-label="Toggle background audio">
-                    Play Audio
-                </button>
-                <div id="nav-placeholder"></div>
-            </header>
-
-            <main class="home-content">
-                <section class="hero" aria-labelledby="home-title">
-                    <div class="hero-copy">
-                        <p class="hero-eyebrow">Network Administrator · IT Strategist</p>
-                        <h1 id="home-title">David Ward</h1>
-                        <p class="hero-tagline">Network Administrator at Warfel Construction</p>
-                        <p class="hero-description">
-                            I build resilient infrastructure, keep critical systems secure, and translate complex technology into
-                            solutions that make work easier for every team member. My focus is on dependable support, clear
-                            communication, and long-term partnerships.
-                        </p>
-                        <div class="hero-actions">
-                            <a class="btn primary" href="about.html">Learn More About Me</a>
-                            <a class="btn" href="resume.html">View Resume</a>
-                        </div>
-                    </div>
-                    <div class="hero-metrics" aria-label="Career highlights">
-                        <article class="metric-card">
-                            <h2>13<span>+</span></h2>
-                            <p>Years delivering network and systems reliability.</p>
-                        </article>
-                        <article class="metric-card">
-                            <h2>24/7</h2>
-                            <p>Support mindset that keeps construction crews productive.</p>
-                        </article>
-                        <article class="metric-card">
-                            <h2>100%</h2>
-                            <p>Commitment to security, VPN adoption, and proactive monitoring.</p>
-                        </article>
-                    </div>
-                </section>
-
-                <section class="intro" aria-labelledby="intro-title">
-                    <h2 id="intro-title">Bridging Business Goals and Technology</h2>
-                    <p>
-                        From modernizing networks to empowering end users, I partner with stakeholders to plan, deploy, and
-                        support the tools they rely on every day. My work blends technical depth with a people-first approach, so
-                        teams feel confident and connected wherever the job takes them.
-                    </p>
-                </section>
-
-                <section class="focus-areas" aria-labelledby="focus-title">
-                    <h2 id="focus-title">Where I Bring the Most Value</h2>
-                    <div class="focus-grid">
-                        <article class="focus-card">
-                            <h3>Infrastructure Leadership</h3>
-                            <p>Designing networks that scale with demand, align with budget, and stay ahead of downtime.</p>
-                        </article>
-                        <article class="focus-card">
-                            <h3>Security &amp; Continuity</h3>
-                            <p>Implementing VPN standards, layered defenses, and backup strategies that protect every jobsite.</p>
-                        </article>
-                        <article class="focus-card">
-                            <h3>Empowering People</h3>
-                            <p>Coaching teams through change, documenting processes, and keeping communication simple and clear.</p>
                         </article>
                     </div>
                 </section>
@@ -184,14 +123,8 @@
                         <p>
                             Ready to discuss infrastructure upgrades, security improvements, or long-term support? I&rsquo;m here
                             to help you chart the path forward.
-                <section class="callout" aria-labelledby="callout-title">
-                    <div class="callout-content">
-                        <h2 id="callout-title">Let&rsquo;s Connect</h2>
-                        <p>
-                            I&rsquo;m always excited to talk about new challenges, whether that&rsquo;s scaling infrastructure, improving
-                            resilience, or mentoring teams. Reach out and we&rsquo;ll build a plan together.
                         </p>
-                        <a class="btn primary" href="mailto:dward@example.com">Start a Conversation</a>
+                        <a class="btn primary" href="mailto:david@wardos.me">Start a Conversation</a>
                     </div>
                 </section>
             </main>

--- a/style.css
+++ b/style.css
@@ -404,20 +404,6 @@ body {
   line-height: 1.7;
 }
 
-.callout {
-  text-align: center;
-}
-
-.callout-content {
-  display: grid;
-  gap: 1rem;
-  justify-items: center;
-}
-
-.callout p {
-  max-width: 520px;
-}
-
 /* Audio control */
 #audioControl {
   padding: 0.75rem 1.5rem;
@@ -628,12 +614,19 @@ body {
 
 /* Callout */
 .callout {
+  text-align: center;
   background: rgba(84, 224, 211, 0.12);
   border-radius: 24px;
   border: 1px solid rgba(125, 248, 222, 0.4);
   padding: clamp(2rem, 5vw, 3rem);
   box-shadow: 0 25px 55px rgba(4, 14, 23, 0.45);
   max-width: 850px;
+}
+
+.callout-content {
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
 }
 
 .callout h2 {
@@ -646,6 +639,7 @@ body {
   margin: 0 0 1.5rem;
   color: #d7edf6;
   line-height: 1.7;
+  max-width: 520px;
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary
- remove duplicated hero, intro, and call-to-action markup that appeared after a bad merge
- keep a single overlay/header structure and include the background audio control in the header
- consolidate callout styling rules to avoid conflicting definitions

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68f7c9794298832ab58e020ef7d6c6ed