### PR TITLE
Remove intro section and emphasize value highlights

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,10 @@
 
         <div class="overlay">
             <header class="site-header">
+                <button id="audioControl" type="button" aria-controls="bgmusic" aria-pressed="false"
+                    aria-label="Toggle background audio">
+                    Play Audio
+                </button>
                 <div id="nav-placeholder"></div>
             </header>
 
@@ -51,16 +55,6 @@
                     </div>
                 </section>
 
-                <section class="intro" aria-labelledby="intro-title">
-                    <h2 id="intro-title">Turning Business Priorities into Technology Wins</h2>
-                    <p>
-                        Construction schedules leave little room for downtime. I partner with project managers,
-                        superintendents, and leadership to identify risks early, stage solutions before they are needed, and
-                        keep communication lines open. The result is a technology environment that supports every crew&rsquo;s
-                        momentum.
-                    </p>
-                </section>
-
                 <section class="value" aria-labelledby="value-title">
                     <div class="section-heading">
                         <h2 id="value-title">What You Can Expect Working With Me</h2>
@@ -88,71 +82,6 @@
                                 Modernization is an ongoing journey. I align upgrades with budgets and business priorities so
                                 investments pay off in productivity, security, and user experience.
                             </p>
-
-        <div class="overlay">
-            <header class="site-header">
-                <button id="audioControl" type="button" aria-controls="bgmusic" aria-pressed="false"
-                    aria-label="Toggle background audio">
-                    Play Audio
-                </button>
-                <div id="nav-placeholder"></div>
-            </header>
-
-            <main class="home-content">
-                <section class="hero" aria-labelledby="home-title">
-                    <div class="hero-copy">
-                        <p class="hero-eyebrow">Network Administrator · IT Strategist</p>
-                        <h1 id="home-title">David Ward</h1>
-                        <p class="hero-tagline">Network Administrator at Warfel Construction</p>
-                        <p class="hero-description">
-                            I build resilient infrastructure, keep critical systems secure, and translate complex technology into
-                            solutions that make work easier for every team member. My focus is on dependable support, clear
-                            communication, and long-term partnerships.
-                        </p>
-                        <div class="hero-actions">
-                            <a class="btn primary" href="about.html">Learn More About Me</a>
-                            <a class="btn" href="resume.html">View Resume</a>
-                        </div>
-                    </div>
-                    <div class="hero-metrics" aria-label="Career highlights">
-                        <article class="metric-card">
-                            <h2>13<span>+</span></h2>
-                            <p>Years delivering network and systems reliability.</p>
-                        </article>
-                        <article class="metric-card">
-                            <h2>24/7</h2>
-                            <p>Support mindset that keeps construction crews productive.</p>
-                        </article>
-                        <article class="metric-card">
-                            <h2>100%</h2>
-                            <p>Commitment to security, VPN adoption, and proactive monitoring.</p>
-                        </article>
-                    </div>
-                </section>
-
-                <section class="intro" aria-labelledby="intro-title">
-                    <h2 id="intro-title">Bridging Business Goals and Technology</h2>
-                    <p>
-                        From modernizing networks to empowering end users, I partner with stakeholders to plan, deploy, and
-                        support the tools they rely on every day. My work blends technical depth with a people-first approach, so
-                        teams feel confident and connected wherever the job takes them.
-                    </p>
-                </section>
-
-                <section class="focus-areas" aria-labelledby="focus-title">
-                    <h2 id="focus-title">Where I Bring the Most Value</h2>
-                    <div class="focus-grid">
-                        <article class="focus-card">
-                            <h3>Infrastructure Leadership</h3>
-                            <p>Designing networks that scale with demand, align with budget, and stay ahead of downtime.</p>
-                        </article>
-                        <article class="focus-card">
-                            <h3>Security &amp; Continuity</h3>
-                            <p>Implementing VPN standards, layered defenses, and backup strategies that protect every jobsite.</p>
-                        </article>
-                        <article class="focus-card">
-                            <h3>Empowering People</h3>
-                            <p>Coaching teams through change, documenting processes, and keeping communication simple and clear.</p>
                         </article>
                     </div>
                 </section>
@@ -184,14 +113,8 @@
                         <p>
                             Ready to discuss infrastructure upgrades, security improvements, or long-term support? I&rsquo;m here
                             to help you chart the path forward.
-                <section class="callout" aria-labelledby="callout-title">
-                    <div class="callout-content">
-                        <h2 id="callout-title">Let&rsquo;s Connect</h2>
-                        <p>
-                            I&rsquo;m always excited to talk about new challenges, whether that&rsquo;s scaling infrastructure, improving
-                            resilience, or mentoring teams. Reach out and we&rsquo;ll build a plan together.
                         </p>
-                        <a class="btn primary" href="mailto:dward@example.com">Start a Conversation</a>
+                        <a class="btn primary" href="mailto:david@wardos.me">Start a Conversation</a>
                     </div>
                 </section>
             </main>

--- a/style.css
+++ b/style.css
@@ -310,32 +310,29 @@ body {
   color: #041d2c;
 }
 
-/* Intro, value, experience, callout */
-.intro,
+/* Value, experience, callout */
 .value,
 .experience,
 .callout {
   background: rgba(8, 24, 36, 0.7);
   border-radius: 22px;
-  padding: clamp(1.75rem, 5vw, 2.5rem);
+  padding: clamp(2.25rem, 6vw, 3rem);
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
   border: 1px solid rgba(91, 159, 191, 0.18);
 }
 
-.intro h2,
 .value h2,
 .experience h2,
 .callout h2 {
   margin-top: 0;
-  font-size: clamp(1.8rem, 4vw, 2.3rem);
+  font-size: clamp(2.1rem, 5vw, 2.7rem);
   color: #f5f7fa;
 }
 
-.intro p,
 .value p,
 .experience p,
 .callout p {
-  font-size: 1.05rem;
+  font-size: 1.12rem;
   line-height: 1.8;
   color: #d6e9f5;
   margin-bottom: 0;
@@ -355,67 +352,61 @@ body {
 
 .value-columns {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: clamp(1.25rem, 4vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1.5rem, 5vw, 2.5rem);
 }
 
 .value-columns article {
-  background: rgba(12, 36, 52, 0.65);
-  border-radius: 18px;
-  padding: clamp(1.25rem, 3vw, 1.75rem);
-  border: 1px solid rgba(94, 172, 204, 0.2);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  background: rgba(12, 36, 52, 0.7);
+  border-radius: 20px;
+  padding: clamp(1.75rem, 4vw, 2.25rem);
+  border: 1px solid rgba(94, 172, 204, 0.28);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .value-columns h3 {
   margin-top: 0;
-  margin-bottom: 0.75rem;
-  font-size: 1.2rem;
+  margin-bottom: 0;
+  font-size: clamp(1.35rem, 3vw, 1.6rem);
   color: #9cd3f0;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.03em;
 }
 
 .value-columns p {
   margin: 0;
   color: #d6e9f5;
+  font-size: 1.1rem;
+  line-height: 1.8;
 }
 
 .experience ol {
   margin: 0;
-  padding-left: 1.5rem;
+  padding-left: 1.75rem;
   display: grid;
-  gap: 1.25rem;
+  gap: clamp(1.5rem, 4vw, 2.25rem);
 }
 
 .experience li {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.6rem;
+  font-size: 1.05rem;
 }
 
 .experience-title {
   font-weight: 600;
   color: #9cd3f0;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
+  font-size: clamp(1.1rem, 3vw, 1.3rem);
 }
 
 .experience-detail {
   color: #d2e6f4;
-  line-height: 1.7;
-}
-
-.callout {
-  text-align: center;
-}
-
-.callout-content {
-  display: grid;
-  gap: 1rem;
-  justify-items: center;
-}
-
-.callout p {
-  max-width: 520px;
+  line-height: 1.85;
+  font-size: 1.12rem;
 }
 
 /* Audio control */
@@ -566,29 +557,6 @@ body {
   line-height: 1.5;
 }
 
-/* Intro */
-.intro {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  background: rgba(3, 11, 19, 0.55);
-  border-radius: 24px;
-  padding: clamp(1.75rem, 4vw, 2.75rem);
-  border: 1px solid rgba(136, 209, 247, 0.25);
-  box-shadow: 0 22px 48px rgba(4, 12, 20, 0.45);
-}
-
-.intro h2 {
-  margin: 0;
-  font-size: clamp(1.9rem, 5vw, 2.6rem);
-}
-
-.intro p {
-  margin: 0;
-  color: #cfe2f1;
-  line-height: 1.8;
-}
-
 /* Focus areas */
 .focus-areas {
   display: flex;
@@ -628,12 +596,19 @@ body {
 
 /* Callout */
 .callout {
+  text-align: center;
   background: rgba(84, 224, 211, 0.12);
   border-radius: 24px;
   border: 1px solid rgba(125, 248, 222, 0.4);
   padding: clamp(2rem, 5vw, 3rem);
   box-shadow: 0 25px 55px rgba(4, 14, 23, 0.45);
   max-width: 850px;
+}
+
+.callout-content {
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
 }
 
 .callout h2 {
@@ -646,6 +621,7 @@ body {
   margin: 0 0 1.5rem;
   color: #d7edf6;
   line-height: 1.7;
+  max-width: 520px;
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary
- remove the "Turning Business Priorities" intro section from the homepage
- enlarge the remaining value and experience sections with bigger typography and spacing
- clean up unused intro styling

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7c9794298832ab58e020ef7d6c6ed