### PR TITLE
Restore hamburger menu and remove audio control

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,10 +19,6 @@
 
         <div class="overlay">
             <header class="site-header">
-                <button id="audioControl" type="button" aria-controls="bgmusic" aria-pressed="false"
-                    aria-label="Toggle background audio">
-                    Play Audio
-                </button>
                 <div id="nav-placeholder"></div>
             </header>
 
@@ -124,9 +120,6 @@
             </footer>
         </div>
 
-        <audio id="bgmusic" src="audio.mp3">
-            Your browser does not support the audio element.
-        </audio>
     </div>
 </body>
 

--- a/nav.html
+++ b/nav.html
@@ -1,13 +1,13 @@
 <div class="menu">
-    <button class="hamburger-icon">
+    <button class="hamburger-icon" type="button" aria-label="Toggle navigation" aria-expanded="false">
         <span></span>
         <span></span>
         <span></span>
     </button>
 </div>
-<div class="nav-links">
+<nav class="nav-links" aria-hidden="true">
     <a href="index.html">Home</a>
     <a href="about.html">About David</a>
     <a href="vpn.html">VPN Essay</a>
     <a href="resume.html">Resume</a>
-</div>
+</nav>

--- a/script.js
+++ b/script.js
@@ -1,61 +1,84 @@
+var NAVIGATION_TEMPLATE = [
+    '<div class="menu">',
+    '    <button class="hamburger-icon" type="button" aria-label="Toggle navigation" aria-expanded="false">',
+    '        <span></span>',
+    '        <span></span>',
+    '        <span></span>',
+    '    </button>',
+    '</div>',
+    '<nav class="nav-links" aria-hidden="true">',
+    '    <a href="index.html">Home</a>',
+    '    <a href="about.html">About David</a>',
+    '    <a href="vpn.html">VPN Essay</a>',
+    '    <a href="resume.html">Resume</a>',
+    '</nav>'
+].join('');
+
 // Setup menu interactions once navigation markup is available
 function setupMenuInteractions() {
     var menu = document.querySelector('.menu');
+    var toggleButton = menu ? menu.querySelector('.hamburger-icon') : null;
     var nav = document.querySelector('.nav-links');
 
-    if (!menu || !nav) {
+    if (!menu || !toggleButton || !nav) {
         return;
     }
 
-    function toggleMenu() {
-        nav.style.width = nav.style.width === '250px' ? '0' : '250px';
-        menu.classList.toggle('change');
+    function openMenu() {
+        nav.style.width = '250px';
+        menu.classList.add('change');
+        toggleButton.setAttribute('aria-expanded', 'true');
+        nav.setAttribute('aria-hidden', 'false');
+    }
+
+    function closeMenu() {
+        nav.style.width = '0';
+        menu.classList.remove('change');
+        toggleButton.setAttribute('aria-expanded', 'false');
+        nav.setAttribute('aria-hidden', 'true');
+    }
+
+    function isMenuOpen() {
+        return menu.classList.contains('change');
+    }
+
+    function toggleMenu(event) {
+        if (event) {
+            event.stopPropagation();
+        }
+
+        if (isMenuOpen()) {
+            closeMenu();
+        } else {
+            openMenu();
+        }
     }
 
     document.addEventListener('click', function (event) {
         var clickInsideMenu = menu.contains(event.target);
         var clickInsideNav = nav.contains(event.target);
 
-        if (!clickInsideMenu && !clickInsideNav && nav.style.width === '250px') {
-            nav.style.width = '0';
-            menu.classList.remove('change');
+        if (!clickInsideMenu && !clickInsideNav && isMenuOpen()) {
+            closeMenu();
         }
     });
 
-    menu.addEventListener('click', function (event) {
-        event.stopPropagation();
-        toggleMenu();
-    });
-}
-
-function setupAudioControls() {
-    var audio = document.getElementById('bgmusic');
-    var control = document.getElementById('audioControl');
-
-    if (!audio || !control) {
-        return;
-    }
-
-    function updateLabel() {
-        control.textContent = audio.paused ? 'Play Audio' : 'Pause Audio';
-        control.setAttribute('aria-pressed', audio.paused ? 'false' : 'true');
-    }
-
-    // Ensure audio is paused on load until user interaction
-    audio.pause();
-    updateLabel();
-
-    control.addEventListener('click', function () {
-        if (audio.paused) {
-            audio.play();
-        } else {
-            audio.pause();
+    document.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape' && isMenuOpen()) {
+            closeMenu();
+            toggleButton.focus();
         }
     });
 
-    audio.addEventListener('play', updateLabel);
-    audio.addEventListener('pause', updateLabel);
-    audio.addEventListener('ended', updateLabel);
+    Array.prototype.forEach.call(nav.querySelectorAll('a'), function (link) {
+        link.addEventListener('click', function () {
+            closeMenu();
+        });
+    });
+
+    menu.addEventListener('click', toggleMenu);
+
+    closeMenu();
 }
 
 document.addEventListener('DOMContentLoaded', function () {
@@ -63,22 +86,24 @@ document.addEventListener('DOMContentLoaded', function () {
 
     if (!placeholder) {
         setupMenuInteractions();
-        setupAudioControls();
         return;
     }
 
     fetch('nav.html')
         .then(function (response) {
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+
             return response.text();
         })
         .then(function (html) {
             placeholder.innerHTML = html;
             setupMenuInteractions();
-            setupAudioControls();
         })
         .catch(function (error) {
-            console.error('Failed to load navigation:', error);
+            console.warn('Failed to load navigation via fetch. Falling back to inline template.', error);
+            placeholder.innerHTML = NAVIGATION_TEMPLATE;
             setupMenuInteractions();
-            setupAudioControls();
         });
 });


### PR DESCRIPTION
## Summary
- add an inline navigation fallback so the hamburger button is always rendered
- remove the background audio control elements and supporting script logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7cd501840832a9be27c6b98f441cb